### PR TITLE
downgrade maven and version of gpg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
-FROM maven:3.6.1
+FROM maven:3.5-jdk-7
 RUN set -ex && \
     apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
+    echo "deb http://archive.debian.org/debian/ jessie main\ndeb-src http://archive.debian.org/debian/ jessie main\ndeb http://security.debian.org jessie/updates main\ndeb-src http://security.debian.org jessie/updates main" > /etc/apt/sources.list && \
     echo "deb http://repos.azulsystems.com/debian stable main" > /etc/apt/sources.list.d/zulu.list && \
-    apt-get autoremove -y openjdk-11-jre-headless openjdk-11-jdk && \
+    apt-get autoremove -y openjdk-7-jre-headless openjdk-7-jdk openjdk-7-jre && \
     apt-get update && apt-get install -y \
     zulu-6 \
     zulu-7 \
@@ -15,4 +16,5 @@ ENV JAVA_HOME_6=/usr/lib/jvm/zulu-6-amd64 \
     JAVA_HOME_7=/usr/lib/jvm/zulu-7-amd64 \
     JAVA_HOME_8=/usr/lib/jvm/zulu-8-amd64 \
     JAVA_HOME_11=/usr/lib/jvm/zulu-11-amd64
-ENV JAVA_HOME=$JAVA_HOME_8
+ENV JAVA_HOME=$JAVA_HOME_8 \
+    JAVA_VERSION=8u171 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # maven-cross-openjdk-docker
-Dockerfile which builds an image containing Maven 3.6.1, OpenJDK 6, OpenJDK 7, OpenJDK 8, and OpenJDK 11.  All OpenJDKs are built and supported by Azul Systems, Inc. [Click here for more Information](https://www.azul.com/downloads/zulu/).  
+Dockerfile which builds an image containing Maven 3.5, OpenJDK 6, OpenJDK 7, OpenJDK 8, and OpenJDK 11.  All OpenJDKs are built and supported by Azul Systems, Inc. [Click here for more Information](https://www.azul.com/downloads/zulu/).  
 
 Azul Systems, Inc. runs the OpenJDK code through the full JCK/TCK to ensure that it complies with the Java SE spec, as defined by the JCP/JSR. In addition, they also run an analysis using tools they've developed to ensure that every single file that is compiled (both static and dynamically generated during the build) has the correct GPLv2 with CPE license header. This way they can also guarantee that there are no licensing issues.


### PR DESCRIPTION
gpg (GnuPG) 1.4.18
JAVA_HOME=/usr/lib/jvm/zulu-8-amd64
JAVA_HOME_8=/usr/lib/jvm/zulu-8-amd64
JAVA_HOME_7=/usr/lib/jvm/zulu-7-amd64
JAVA_HOME_6=/usr/lib/jvm/zulu-6-amd64
JAVA_HOME_11=/usr/lib/jvm/zulu-11-amd64